### PR TITLE
Feature/s3: add upload size limit, image_key contract, and key usage in events/expenses

### DIFF
--- a/backend/tevent/src/main/java/com/tbank/tevent/event/EventMapper.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/event/EventMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class EventMapper {
     public EventResponse mapToResponse(Event event, List<CategoryResponse> categories, Long count) {
         List<String> eventCategoryNames = categories.stream()
-                .filter(c -> c.eventId().equals(event.getId()))
+                .filter(c -> event.getId().equals(c.eventId()))
                 .map(CategoryResponse::name)
                 .toList();
         return new EventResponse(
@@ -21,7 +21,7 @@ public class EventMapper {
                 event.getEndDate(),
                 eventCategoryNames,
                 EventStatusCalculator.calculate(event.getStartDate(), event.getEndDate()),
-                null,
+                event.getImageKey(),
                 event.getOwnerId(),
                 count
         );

--- a/backend/tevent/src/main/java/com/tbank/tevent/event/EventResponse.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/event/EventResponse.java
@@ -1,8 +1,6 @@
 package com.tbank.tevent.event;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +14,7 @@ public record EventResponse (
     LocalDateTime endDate,
     List<String> categories,
     String status,
-    String imageUrl,
+    @JsonProperty("image_key") String imageKey,
     UUID ownerId,
     Long countOfParticipants
 ){}

--- a/backend/tevent/src/main/java/com/tbank/tevent/event/EventService.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/event/EventService.java
@@ -12,6 +12,7 @@ import com.tbank.tevent.repo.InviteTokenRepository;
 import com.tbank.tevent.repo.entity.Event;
 import com.tbank.tevent.repo.entity.EventUser;
 import com.tbank.tevent.repo.entity.InviteToken;
+import com.tbank.tevent.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class EventService {
     private final CategoryService categoryService;
     private final InviteTokenRepository inviteTokenRepository;
     private final EventMapper eventMapper;
+    private final S3Service s3Service;
 
     @Transactional
     public EventResponse createEvent(EventRequest request) {
@@ -47,6 +49,7 @@ public class EventService {
                 .createdAt(now)
                 .build();
         inviteToken = inviteTokenRepository.save(inviteToken);
+        s3Service.useKey(currentUserId, request.imageKey());
 
         Event event = new Event();
         event.setTitle(request.title());
@@ -95,11 +98,13 @@ public class EventService {
         if (request.description() != null) event.setDescription(request.description());
         if (request.startDate() != null) event.setStartDate(request.startDate());
         if (request.endDate() != null) event.setEndDate(request.endDate());
-        if (request.imageKey() != null) event.setImageKey(request.imageKey());
+        if (request.imageKey() != null) {
+            s3Service.useKey(currentUserId, request.imageKey());
+            event.setImageKey(request.imageKey());
+        }
 
         eventRepository.saveAndFlush(event);
 
-        // Sync categories if provided
         if (request.categories() != null) {
             categoryService.syncCategoriesWithEvent(eventId, request.categories());
         }

--- a/backend/tevent/src/main/java/com/tbank/tevent/event/dto/EventRequest.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/event/dto/EventRequest.java
@@ -1,5 +1,7 @@
 package com.tbank.tevent.event.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -14,6 +16,7 @@ public record EventRequest(
     LocalDateTime startDate,
     @NotNull
     LocalDateTime endDate,
-    String imageKey,
+    @JsonProperty("image_key") @JsonAlias({"imageUrl", "image_url"}) String imageKey,
+    @JsonProperty("category") @JsonAlias("categories")
     List<String> categories
 ){}

--- a/backend/tevent/src/main/java/com/tbank/tevent/expenses/CreateExpenseRequest.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/expenses/CreateExpenseRequest.java
@@ -1,5 +1,7 @@
 package com.tbank.tevent.expenses;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import java.math.BigDecimal;
 import java.util.List;
@@ -9,8 +11,8 @@ public record CreateExpenseRequest(
         @NotBlank
         String title,
         String description,
-        BigDecimal totalAmount,
-        String imageUrl,
-        List<String> categories,
+        @JsonAlias({"amount", "total_amount"}) BigDecimal totalAmount,
+        @JsonProperty("image_key") @JsonAlias({"imageUrl", "image_url"}) String imageKey,
+        @JsonProperty("categories") @JsonAlias("category") List<String> categories,
         List<UUID> participantIds
 ) {}

--- a/backend/tevent/src/main/java/com/tbank/tevent/expenses/ExpenseAuthorService.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/expenses/ExpenseAuthorService.java
@@ -4,6 +4,7 @@ import com.tbank.tevent.SecurityUtils;
 import com.tbank.tevent.category.CategoryRepository;
 import com.tbank.tevent.repo.*;
 import com.tbank.tevent.repo.entity.*;
+import com.tbank.tevent.s3.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -26,6 +27,7 @@ public class ExpenseAuthorService {
     private final ExpenseSplitRepository splitRepository;
     private final ExpenseCategoryRepository expenseCategoryRepository;
     private final CategoryRepository categoryRepository;
+    private final S3Service s3Service;
 
     private static final List<String> VISIBLE_STATUSES = List.of("PENDING", "CONFIRMED", "REJECTED");
 
@@ -39,6 +41,7 @@ public class ExpenseAuthorService {
         if (request.participantIds() != null && request.participantIds().contains(currentUserId)) {
             throw new IllegalArgumentException("Вы не можете добавить себя в список должников.");
         }
+        s3Service.useKey(currentUserId, request.imageKey());
 
         Expense expense = Expense.builder()
                 .eventId(eventId)
@@ -46,7 +49,7 @@ public class ExpenseAuthorService {
                 .title(request.title())
                 .description(request.description())
                 .amount(request.totalAmount())
-                .imageUrl(request.imageUrl())
+                .imageUrl(request.imageKey())
                 .status("PENDING")
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -59,7 +62,6 @@ public class ExpenseAuthorService {
 
     @Transactional(readOnly = true)
     public EventExpensesResponse getEventExpenses(UUID eventId) {
-        // Показываем только те, что прошли стадию планирования или уже подтверждены
         List<Expense> expenses = expenseRepository.findAllByEventIdAndStatusInOrderByCreatedAtDesc(eventId, VISIBLE_STATUSES);
 
         if (expenses.isEmpty()) return new EventExpensesResponse(List.of(), BigDecimal.ZERO);
@@ -78,6 +80,7 @@ public class ExpenseAuthorService {
                     e.getAmount(),
                     e.getPayerId(),
                     e.getStatus(),
+                    e.getImageUrl(),
                     catMap.getOrDefault(e.getId(), List.of()),
                     debtors.stream().limit(10).toList(),
                     debtors.size(),
@@ -100,10 +103,11 @@ public class ExpenseAuthorService {
         if (!expense.getPayerId().equals(currentUserId)) {
             throw new AccessDeniedException("Только плательщик может редактировать расход.");
         }
+        s3Service.useKey(currentUserId, request.imageKey());
 
         expense.setDescription(request.description());
         expense.setAmount(request.totalAmount());
-        expense.setImageUrl(request.imageUrl());
+        expense.setImageUrl(request.imageKey());
         expense.setStatus("PLANNED");
         expenseRepository.save(expense);
 
@@ -120,7 +124,6 @@ public class ExpenseAuthorService {
         Expense expense = expenseRepository.findById(expenseId)
                 .orElseThrow(() -> new EntityNotFoundException("Expense not found"));
 
-        // 1. Проверка прав: Удалить может только плательщик
         if (!expense.getPayerId().equals(currentUserId)) {
             throw new AccessDeniedException("Только плательщик может удалить расход");
         }
@@ -131,7 +134,7 @@ public class ExpenseAuthorService {
     }
 
     private void processSplits(UUID expenseId, BigDecimal total, List<UUID> participants) {
-        if (participants.isEmpty()) return;
+        if (participants == null || participants.isEmpty()) return;
 
         int totalPeople = participants.size() + 1;
         BigDecimal share = total.divide(BigDecimal.valueOf(totalPeople), 2, RoundingMode.HALF_UP);

--- a/backend/tevent/src/main/java/com/tbank/tevent/expenses/ExpenseResponse.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/expenses/ExpenseResponse.java
@@ -1,5 +1,7 @@
 package com.tbank.tevent.expenses;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -7,11 +9,12 @@ import java.util.UUID;
 
 public record ExpenseResponse(
         UUID id,
-        String description,
         String title,
+        String description,
         BigDecimal totalAmount,
         UUID payerId,
         String status,
+        @JsonProperty("image_key") String imageKey,
         List<String> categories,
         List<UUID> firstTenParticipants,
         int totalParticipantsCount,

--- a/backend/tevent/src/main/java/com/tbank/tevent/s3/S3Controller.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/s3/S3Controller.java
@@ -26,7 +26,12 @@ public class S3Controller {
             Authentication authentication
     ) {
         UUID userId = authenticatedUserId(authentication);
-        S3Service.PresignedUpload upload = s3Service.generateUploadUrl(userId, request.fileName(), request.contentType());
+        S3Service.PresignedUpload upload = s3Service.generateUploadUrl(
+                userId,
+                request.fileName(),
+                request.contentType(),
+                request.fileSizeBytes()
+        );
         return ResponseEntity.ok(new UploadUrlResponse(upload.imageKey(), upload.uploadUrl(), upload.expiresInSeconds()));
     }
 

--- a/backend/tevent/src/main/java/com/tbank/tevent/s3/S3Service.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/s3/S3Service.java
@@ -10,6 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.net.URL;
 import java.time.Duration;
@@ -34,6 +38,7 @@ public class S3Service {
 
     private final S3Template s3Template;
     private final StringRedisTemplate redisTemplate;
+    private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.bucket-name:tbank-receipts}")
     private String bucketName;
@@ -47,12 +52,17 @@ public class S3Service {
     @Value("${app.s3.cleanup-batch-size:100}")
     private int cleanupBatchSize;
 
-    public PresignedUpload generateUploadUrl(UUID userId, String fileName, String contentType) {
+    @Value("${app.s3.max-file-size-bytes:3145728}")
+    private long maxFileSizeBytes;
+
+    public PresignedUpload generateUploadUrl(UUID userId, String fileName, String contentType, Long fileSizeBytes) {
         try {
             cleanupExpiredPendingUploads();
         } catch (Exception ex) {
             log.warn("Failed to cleanup expired pending uploads", ex);
         }
+
+        validateExpectedFileSize(fileSizeBytes);
 
         String normalizedContentType = normalizeContentType(contentType);
         String normalizedFileName = normalizeFileName(fileName);
@@ -109,12 +119,12 @@ public class S3Service {
             return;
         }
 
-        // Backward compatibility: old clients may still pass direct external URLs.
         if (!s3Key.startsWith("receipts/")) {
             return;
         }
 
         validateOwnership(userId, s3Key);
+        enforceFileSizeLimit(s3Key);
 
         try {
             removePendingUpload(s3Key);
@@ -123,6 +133,42 @@ public class S3Service {
         }
 
         log.info("Image key marked as used, userId={}, key={}", userId, s3Key);
+    }
+
+    private void validateExpectedFileSize(Long fileSizeBytes) {
+        if (fileSizeBytes == null) {
+            return;
+        }
+        if (fileSizeBytes <= 0) {
+            throw new InvalidImageRequestException("file_size_bytes must be greater than zero");
+        }
+        if (fileSizeBytes > maxFileSizeBytes) {
+            throw new InvalidImageRequestException("File size exceeds 3MB limit");
+        }
+    }
+
+    private void enforceFileSizeLimit(String s3Key) {
+        try {
+            Long objectSize = s3Client.headObject(
+                    HeadObjectRequest.builder()
+                            .bucket(bucketName)
+                            .key(s3Key)
+                            .build()
+            ).contentLength();
+
+            if (objectSize != null && objectSize > maxFileSizeBytes) {
+                s3Template.deleteObject(bucketName, s3Key);
+                removePendingUpload(s3Key);
+                throw new InvalidImageRequestException("File size exceeds 3MB limit");
+            }
+        } catch (NoSuchKeyException ex) {
+            throw new ImageNotFoundException();
+        } catch (S3Exception ex) {
+            if (ex.statusCode() == 404) {
+                throw new ImageNotFoundException();
+            }
+            throw ex;
+        }
     }
 
     private String normalizeContentType(String contentType) {

--- a/backend/tevent/src/main/java/com/tbank/tevent/s3/dto/CreateImageUploadUrlRequest.java
+++ b/backend/tevent/src/main/java/com/tbank/tevent/s3/dto/CreateImageUploadUrlRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record CreateImageUploadUrlRequest(
         @NotBlank @Size(max = 255) @JsonProperty("file_name") String fileName,
-        @NotBlank @Size(max = 100) @JsonProperty("content_type") String contentType
+        @NotBlank @Size(max = 100) @JsonProperty("content_type") String contentType,
+        @JsonProperty("file_size_bytes") Long fileSizeBytes
 ) {
 }

--- a/backend/tevent/src/main/resources/application.yaml
+++ b/backend/tevent/src/main/resources/application.yaml
@@ -38,15 +38,10 @@ app:
     presign-ttl-minutes: 15
     pending-ttl-hours: 1
     cleanup-batch-size: 100
+    max-file-size-bytes: 3145728
   security:
     jwt:
       secret: ${JWT_SECRET}
       access-token-expiration-minutes: 15
       refresh-token-expiration-days: ${JWT_REFRESH_TOKEN_EXPIRATION_DAYS:30}
       cookie-secure: ${JWT_COOKIE_SECURE:false}
-
-receipt:
-  image:
-    max-width: 1920
-    quality: 0.75
-    format: webp

--- a/backend/tevent/src/test/java/com/tbank/tevent/event/EventIntegrationTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/event/EventIntegrationTest.java
@@ -61,6 +61,7 @@ class EventIntegrationTest {
                 "description", "Best party ever",
                 "startDate", LocalDateTime.now().plusDays(1).toString(),
                 "endDate", LocalDateTime.now().plusDays(2).toString(),
+                "image_key", "custom-image-key",
                 "categories", List.of("Music", "Food")
         );
 
@@ -71,7 +72,9 @@ class EventIntegrationTest {
                 .expectStatus().isCreated()
                 .expectBody(String.class).returnResult().getResponseBody();
 
-        UUID eventId = UUID.fromString(objectMapper.readTree(eventRespStr).get("id").asText());
+        JsonNode createdEvent = objectMapper.readTree(eventRespStr);
+        UUID eventId = UUID.fromString(createdEvent.get("id").asText());
+        assertThat(createdEvent.get("image_key").asText()).isEqualTo("custom-image-key");
 
         // --- 3. Алиса получает токен инвайта ---
         String tokenRespStr = webTestClient.get().uri("/events/" + eventId + "/token")

--- a/backend/tevent/src/test/java/com/tbank/tevent/event/EventServiceTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/event/EventServiceTest.java
@@ -1,0 +1,166 @@
+package com.tbank.tevent.event;
+
+import com.tbank.tevent.category.CategoryService;
+import com.tbank.tevent.category.dto.CategoryResponse;
+import com.tbank.tevent.event.dto.EventRequest;
+import com.tbank.tevent.repo.EventRepository;
+import com.tbank.tevent.repo.EventUserRepository;
+import com.tbank.tevent.repo.InviteTokenRepository;
+import com.tbank.tevent.repo.entity.Event;
+import com.tbank.tevent.repo.entity.InviteToken;
+import com.tbank.tevent.repo.entity.User;
+import com.tbank.tevent.s3.S3Service;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private EventUserRepository eventUserRepository;
+    @Mock
+    private CategoryService categoryService;
+    @Mock
+    private InviteTokenRepository inviteTokenRepository;
+    @Mock
+    private EventMapper eventMapper;
+    @Mock
+    private S3Service s3Service;
+
+    private EventService eventService;
+    private UUID currentUserId;
+
+    @BeforeEach
+    void setUp() {
+        eventService = new EventService(eventRepository, eventUserRepository, categoryService, inviteTokenRepository, eventMapper, s3Service);
+        currentUserId = UUID.randomUUID();
+        User user = User.builder().id(currentUserId).login("user").build();
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(user, null));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createEventShouldUseImageKeyAndPersistIt() {
+        UUID eventId = UUID.randomUUID();
+        UUID tokenId = UUID.randomUUID();
+        String imageKey = "receipts/" + currentUserId + "/event.jpg";
+
+        EventRequest request = new EventRequest(
+                "Title",
+                "Desc",
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(2),
+                imageKey,
+                List.of("Food")
+        );
+
+        InviteToken savedToken = InviteToken.builder().id(tokenId).token("invite").build();
+        when(inviteTokenRepository.save(any(InviteToken.class))).thenReturn(savedToken);
+
+        Event persistedEvent = new Event();
+        persistedEvent.setId(eventId);
+        persistedEvent.setOwnerId(currentUserId);
+        persistedEvent.setInviteTokenId(tokenId);
+        persistedEvent.setTitle(request.title());
+        persistedEvent.setDescription(request.description());
+        persistedEvent.setStartDate(request.startDate());
+        persistedEvent.setEndDate(request.endDate());
+        persistedEvent.setImageKey(imageKey);
+
+        when(eventRepository.saveAndFlush(any(Event.class))).thenReturn(persistedEvent);
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(persistedEvent));
+        when(eventUserRepository.countByEventId(eventId)).thenReturn(1L);
+        when(categoryService.findAllByEventId(eventId)).thenReturn(List.of());
+        EventResponse expected = new EventResponse(
+                eventId,
+                request.title(),
+                request.description(),
+                request.startDate(),
+                request.endDate(),
+                List.of(),
+                "PLANNED",
+                imageKey,
+                currentUserId,
+                1L
+        );
+        when(eventMapper.mapToResponse(eq(persistedEvent), any(List.class), eq(1L))).thenReturn(expected);
+
+        EventResponse result = eventService.createEvent(request);
+
+        assertThat(result.imageKey()).isEqualTo(imageKey);
+        verify(s3Service).useKey(currentUserId, imageKey);
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).saveAndFlush(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getImageKey()).isEqualTo(imageKey);
+    }
+
+    @Test
+    void updateEventShouldUseImageKeyWhenProvided() {
+        UUID eventId = UUID.randomUUID();
+        String newImageKey = "receipts/" + currentUserId + "/updated.jpg";
+
+        Event existing = new Event();
+        existing.setId(eventId);
+        existing.setOwnerId(currentUserId);
+        existing.setTitle("Old");
+        existing.setDescription("Old");
+        existing.setStartDate(LocalDateTime.now().plusDays(1));
+        existing.setEndDate(LocalDateTime.now().plusDays(2));
+
+        EventRequest request = new EventRequest(
+                null,
+                null,
+                null,
+                null,
+                newImageKey,
+                null
+        );
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(existing));
+        when(eventUserRepository.countByEventId(eventId)).thenReturn(1L);
+        when(categoryService.findAllByEventId(eventId)).thenReturn(List.<CategoryResponse>of());
+        EventResponse expected = new EventResponse(
+                eventId,
+                existing.getTitle(),
+                existing.getDescription(),
+                existing.getStartDate(),
+                existing.getEndDate(),
+                List.of(),
+                "PLANNED",
+                newImageKey,
+                currentUserId,
+                1L
+        );
+        when(eventMapper.mapToResponse(eq(existing), any(List.class), eq(1L))).thenReturn(expected);
+
+        EventResponse result = eventService.updateEvent(eventId, request);
+
+        assertThat(result.imageKey()).isEqualTo(newImageKey);
+        verify(s3Service).useKey(currentUserId, newImageKey);
+        verify(eventRepository).saveAndFlush(existing);
+        assertThat(existing.getImageKey()).isEqualTo(newImageKey);
+    }
+}

--- a/backend/tevent/src/test/java/com/tbank/tevent/expenses/ExpenseAuthorServiceTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/expenses/ExpenseAuthorServiceTest.java
@@ -1,0 +1,147 @@
+package com.tbank.tevent.expenses;
+
+import com.tbank.tevent.category.CategoryRepository;
+import com.tbank.tevent.repo.EventRepository;
+import com.tbank.tevent.repo.ExpenseCategoryRepository;
+import com.tbank.tevent.repo.ExpenseRepository;
+import com.tbank.tevent.repo.ExpenseSplitRepository;
+import com.tbank.tevent.repo.entity.Event;
+import com.tbank.tevent.repo.entity.Expense;
+import com.tbank.tevent.repo.entity.ExpenseSplit;
+import com.tbank.tevent.repo.entity.User;
+import com.tbank.tevent.s3.S3Service;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseAuthorServiceTest {
+
+    @Mock
+    private ExpenseRepository expenseRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private ExpenseSplitRepository splitRepository;
+    @Mock
+    private ExpenseCategoryRepository expenseCategoryRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private S3Service s3Service;
+
+    private ExpenseAuthorService expenseAuthorService;
+    private UUID currentUserId;
+
+    @BeforeEach
+    void setUp() {
+        expenseAuthorService = new ExpenseAuthorService(
+                expenseRepository,
+                eventRepository,
+                splitRepository,
+                expenseCategoryRepository,
+                categoryRepository,
+                s3Service
+        );
+        currentUserId = UUID.randomUUID();
+        User user = User.builder().id(currentUserId).login("payer").build();
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(user, null));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void createExpenseShouldUseImageKeyAndCreateSplits() {
+        UUID eventId = UUID.randomUUID();
+        UUID expenseId = UUID.randomUUID();
+        UUID participantId = UUID.randomUUID();
+        String imageKey = "receipts/" + currentUserId + "/check.jpg";
+
+        Event event = Event.builder().id(eventId).ownerId(currentUserId).build();
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        CreateExpenseRequest request = new CreateExpenseRequest(
+                "Dinner",
+                "Team",
+                new BigDecimal("100.00"),
+                imageKey,
+                null,
+                List.of(participantId)
+        );
+
+        when(expenseRepository.saveAndFlush(any(Expense.class))).thenAnswer(invocation -> {
+            Expense e = invocation.getArgument(0);
+            e.setId(expenseId);
+            return e;
+        });
+
+        UUID result = expenseAuthorService.createExpense(eventId, request);
+
+        assertThat(result).isEqualTo(expenseId);
+        verify(s3Service).useKey(currentUserId, imageKey);
+
+        ArgumentCaptor<Expense> expenseCaptor = ArgumentCaptor.forClass(Expense.class);
+        verify(expenseRepository).saveAndFlush(expenseCaptor.capture());
+        assertThat(expenseCaptor.getValue().getImageUrl()).isEqualTo(imageKey);
+
+        ArgumentCaptor<List<ExpenseSplit>> splitCaptor = ArgumentCaptor.forClass(List.class);
+        verify(splitRepository).saveAll(splitCaptor.capture());
+        assertThat(splitCaptor.getValue()).hasSize(1);
+        assertThat(splitCaptor.getValue().get(0).getAmount()).isEqualByComparingTo("50.00");
+        assertThat(splitCaptor.getValue().get(0).getUserId()).isEqualTo(participantId);
+    }
+
+    @Test
+    void updateExpenseShouldUseImageKeyAndUpdateStoredValue() {
+        UUID eventId = UUID.randomUUID();
+        UUID expenseId = UUID.randomUUID();
+        String oldImageKey = "receipts/" + currentUserId + "/old.jpg";
+        String newImageKey = "receipts/" + currentUserId + "/new.jpg";
+
+        Expense existing = Expense.builder()
+                .id(expenseId)
+                .eventId(eventId)
+                .payerId(currentUserId)
+                .amount(new BigDecimal("80.00"))
+                .imageUrl(oldImageKey)
+                .status("PENDING")
+                .title("Old")
+                .build();
+        when(expenseRepository.findById(expenseId)).thenReturn(Optional.of(existing));
+
+        CreateExpenseRequest request = new CreateExpenseRequest(
+                "Dinner",
+                "Updated",
+                new BigDecimal("120.00"),
+                newImageKey,
+                null,
+                null
+        );
+
+        expenseAuthorService.updateExpense(eventId, expenseId, request);
+
+        verify(s3Service).useKey(currentUserId, newImageKey);
+        verify(expenseRepository).save(existing);
+        assertThat(existing.getImageUrl()).isEqualTo(newImageKey);
+        assertThat(existing.getAmount()).isEqualByComparingTo("120.00");
+    }
+}

--- a/backend/tevent/src/test/java/com/tbank/tevent/expenses/ExpenseIntegrationTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/expenses/ExpenseIntegrationTest.java
@@ -107,7 +107,7 @@ class ExpenseIntegrationTest {
                 "title", "Restaurant Bill",
                 "description", "Dinner for two",
                 "totalAmount", 100.0,
-                "imageUrl", "http://example.com/bill.jpg",
+                "image_key", "custom-expense-image-key",
                 "categories", List.of(),
                 "participantIds", List.of(bobSession.userId().toString()) // Боб - участник
         );
@@ -130,6 +130,7 @@ class ExpenseIntegrationTest {
 
         JsonNode expenses = objectMapper.readTree(expensesStr).get("expenses");
         assertThat(expenses.get(0).get("status").asText()).isEqualTo("PENDING");
+        assertThat(expenses.get(0).get("image_key").asText()).isEqualTo("custom-expense-image-key");
 
         // --- 7. Проверка: Боб видит расход в своем inbox ---
         String participantInboxStr = webTestClient.get().uri("/expenses/participant/inbox")
@@ -139,8 +140,8 @@ class ExpenseIntegrationTest {
                 .expectBody(String.class).returnResult().getResponseBody();
 
         JsonNode participantInbox = objectMapper.readTree(participantInboxStr);
-        assertThat(participantInbox.get("pending").size()).isEqualTo(1);
-        assertThat(participantInbox.get("pending").get(0).get("title").asText()).isEqualTo("Restaurant Bill");
+        assertThat(participantInbox.get("pendingConfirmations").size()).isEqualTo(1);
+        assertThat(participantInbox.get("pendingConfirmations").get(0).get("description").asText()).isEqualTo("Restaurant Bill");
 
         // --- 8. Боб подтверждает свою долю ---
         webTestClient.post().uri("/expenses/participant/" + expenseId + "/confirm")
@@ -166,7 +167,7 @@ class ExpenseIntegrationTest {
                 .expectBody(String.class).returnResult().getResponseBody();
 
         JsonNode updatedParticipantInbox = objectMapper.readTree(updatedParticipantInboxStr);
-        assertThat(updatedParticipantInbox.get("pending").size()).isEqualTo(0);
+        assertThat(updatedParticipantInbox.get("pendingConfirmations").size()).isEqualTo(0);
     }
 
     private TestSession registerUser(String login, String email, String password, String token) throws Exception {

--- a/backend/tevent/src/test/java/com/tbank/tevent/s3/S3IntegrationTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/s3/S3IntegrationTest.java
@@ -1,0 +1,86 @@
+package com.tbank.tevent.s3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class S3IntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withEnv("LC_ALL", "en_US.UTF-8")
+            .withEnv("POSTGRES_INITDB_ARGS", "--lc-messages=en_US.UTF-8")
+            .withReuse(true);
+
+    @LocalServerPort
+    private int port;
+
+    private WebTestClient webTestClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        this.webTestClient = WebTestClient.bindToServer()
+                .baseUrl("http://localhost:" + port)
+                .build();
+    }
+
+    @Test
+    void createUploadUrlShouldReturnBadRequestWhenFileSizeExceedsLimit() throws Exception {
+        String cookie = registerUser("s3user", "passsss123");
+
+        String body = webTestClient.post().uri("/s3/upload")
+                .header("Cookie", cookie)
+                .bodyValue(Map.of(
+                        "file_name", "check",
+                        "content_type", "image/jpeg",
+                        "file_size_bytes", 3 * 1024 * 1024 + 1
+                ))
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+
+        JsonNode error = objectMapper.readTree(body);
+        assertThat(error.get("status").asInt()).isEqualTo(400);
+    }
+
+    private String registerUser(String login, String password) {
+        Map<String, Object> req = new HashMap<>();
+        req.put("login", login);
+        req.put("password", password);
+        req.put("firstName", login);
+        req.put("secondName", "Family");
+
+        var result = webTestClient.post().uri("/auth/register")
+                .bodyValue(req)
+                .exchange()
+                .expectStatus().isCreated()
+                .returnResult(String.class);
+
+        String cookie = result.getResponseHeaders().getFirst("Set-Cookie");
+        if (cookie != null && cookie.contains(";")) {
+            cookie = cookie.split(";")[0];
+        }
+        return cookie;
+    }
+}

--- a/backend/tevent/src/test/java/com/tbank/tevent/s3/S3ServiceTest.java
+++ b/backend/tevent/src/test/java/com/tbank/tevent/s3/S3ServiceTest.java
@@ -1,0 +1,127 @@
+package com.tbank.tevent.s3;
+
+import com.tbank.tevent.s3.exception.ImageAccessDeniedException;
+import com.tbank.tevent.s3.exception.InvalidImageRequestException;
+import io.awspring.cloud.s3.S3Template;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+import java.net.URL;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    @Mock
+    private S3Template s3Template;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+    @Mock
+    private S3Client s3Client;
+
+    private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        s3Service = new S3Service(s3Template, redisTemplate, s3Client);
+        ReflectionTestUtils.setField(s3Service, "bucketName", "tbank-receipts");
+        ReflectionTestUtils.setField(s3Service, "presignTtlMinutes", 15L);
+        ReflectionTestUtils.setField(s3Service, "pendingUploadTtlHours", 1L);
+        ReflectionTestUtils.setField(s3Service, "cleanupBatchSize", 100);
+        ReflectionTestUtils.setField(s3Service, "maxFileSizeBytes", 3L * 1024 * 1024);
+
+        lenient().when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+    }
+
+    @Test
+    void generateUploadUrlShouldRejectTooLargeExpectedSize() {
+        UUID userId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> s3Service.generateUploadUrl(userId, "check", "image/jpeg", 3L * 1024 * 1024 + 1))
+                .isInstanceOf(InvalidImageRequestException.class)
+                .hasMessage("File size exceeds 3MB limit");
+    }
+
+    @Test
+    void generateUploadUrlShouldCreatePresignedUrlAndJpgKey() throws Exception {
+        UUID userId = UUID.randomUUID();
+        when(s3Template.createSignedPutURL(anyString(), anyString(), any(), any(), anyString()))
+                .thenReturn(new URL("http://localhost/upload"));
+
+        S3Service.PresignedUpload result = s3Service.generateUploadUrl(userId, "receipt", "image/jpeg", 123L);
+
+        assertThat(result.uploadUrl()).isEqualTo("http://localhost/upload");
+        assertThat(result.expiresInSeconds()).isEqualTo(900);
+        assertThat(result.imageKey()).startsWith("receipts/" + userId + "/").endsWith(".jpg");
+        verify(zSetOperations).add(eq("s3:pending:index"), eq(result.imageKey()), anyDouble());
+    }
+
+    @Test
+    void useKeyShouldIgnoreNonReceiptsKeys() {
+        s3Service.useKey(UUID.randomUUID(), "http://example.com/image.jpg");
+
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    void useKeyShouldRejectForeignOwnership() {
+        UUID userId = UUID.randomUUID();
+        UUID anotherUserId = UUID.randomUUID();
+        String key = "receipts/" + anotherUserId + "/image.jpg";
+
+        assertThatThrownBy(() -> s3Service.useKey(userId, key))
+                .isInstanceOf(ImageAccessDeniedException.class);
+    }
+
+    @Test
+    void useKeyShouldDeleteOversizeObject() {
+        UUID userId = UUID.randomUUID();
+        String key = "receipts/" + userId + "/image.jpg";
+        when(s3Client.headObject(any(software.amazon.awssdk.services.s3.model.HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().contentLength(4L * 1024 * 1024).build());
+
+        assertThatThrownBy(() -> s3Service.useKey(userId, key))
+                .isInstanceOf(InvalidImageRequestException.class)
+                .hasMessage("File size exceeds 3MB limit");
+
+        verify(s3Template).deleteObject("tbank-receipts", key);
+        verify(zSetOperations).remove("s3:pending:index", key);
+    }
+
+    @Test
+    void useKeyShouldRemovePendingForValidObject() {
+        UUID userId = UUID.randomUUID();
+        String key = "receipts/" + userId + "/image.jpg";
+        when(s3Client.headObject(any(software.amazon.awssdk.services.s3.model.HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().contentLength(1024L).build());
+
+        s3Service.useKey(userId, key);
+
+        verify(zSetOperations).remove("s3:pending:index", key);
+        ArgumentCaptor<software.amazon.awssdk.services.s3.model.HeadObjectRequest> captor =
+                ArgumentCaptor.forClass(software.amazon.awssdk.services.s3.model.HeadObjectRequest.class);
+        verify(s3Client).headObject(captor.capture());
+        assertThat(captor.getValue().bucket()).isEqualTo("tbank-receipts");
+        assertThat(captor.getValue().key()).isEqualTo(key);
+    }
+}


### PR DESCRIPTION
Добавлены:
- лимит 3MB на сохранение изображений
- юнит и интеграционные тесты для S3
- ключи изображений в dto расходов и событий
Изменены тесты для расходов и событий под новый функционал 